### PR TITLE
[FE]-Detail View 구축

### DIFF
--- a/front/black-gomushin/src/App.js
+++ b/front/black-gomushin/src/App.js
@@ -4,6 +4,7 @@ import { StylesProvider } from '@material-ui/core';
 import GlobalStyle from './components/common/globalStyle';
 import LoginView from './pages/LoginView';
 import MainView from './pages/MainView';
+import DetailView from './pages/DetailView';
 import { useSelector } from 'react-redux';
 
 const App = () => {
@@ -18,7 +19,8 @@ const App = () => {
   const serviceRouter = (
     <>
       <Switch>
-        <Route path="/" component={MainView} />
+        <Route exact path="/" component={MainView} />
+        <Route path="/detail" component={DetailView} />
       </Switch>
     </>
   );

--- a/front/black-gomushin/src/components/MainView/Div/ItemList.jsx
+++ b/front/black-gomushin/src/components/MainView/Div/ItemList.jsx
@@ -11,6 +11,11 @@ const ItemCard = styled.div`
   height: 300px;
   background-color: #e3ecf1;
   border-radius: 20px;
+  &:hover {
+    cursor: pointer;
+    transform: scale(1.1);
+    background-color: #f5eeed;
+  }
 `;
 
 const ItemImg = styled.img`

--- a/front/black-gomushin/src/components/MainView/Div/ItemList.jsx
+++ b/front/black-gomushin/src/components/MainView/Div/ItemList.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
+import { useHistory } from 'react-router-dom';
 import { getAxios } from '../../../utils/axios';
 import ItemInfo from './ItemInfo';
 
@@ -17,6 +18,7 @@ const ItemImg = styled.img`
 `;
 
 const ItemList = () => {
+  const history = useHistory();
   const [allItem, setAllItem] = useState([]);
   const [offset, setOffset] = useState(0);
 
@@ -27,7 +29,7 @@ const ItemList = () => {
     };
     const { data } = await getAxios('/items', params);
     setAllItem([...allItem, ...data]);
-    setOffset(offset + 7);
+    setOffset(offset + 5);
   };
 
   const checkScroll = () => {
@@ -53,7 +55,7 @@ const ItemList = () => {
     <div>
       {allItem.map((item) => {
         return (
-          <ItemCard key={item.id}>
+          <ItemCard onClick={() => history.push('/detail', { item })} key={item.id}>
             <ItemImg src={item.imageurl}></ItemImg>
             <ItemInfo info={item}></ItemInfo>
           </ItemCard>

--- a/front/black-gomushin/src/pages/DetailView.jsx
+++ b/front/black-gomushin/src/pages/DetailView.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import styled from 'styled-components';
+import Header from '../components/common/header';
+import Footer from '../components/common/footer';
+
+const DetailContainer = styled.div`
+  display: flex;
+  width: 100%;
+  height: 100%;
+  flex-direction: column;
+  justify-content: center;
+`;
+
+const DetailItem = styled.div`
+  display: flex;
+  justify-content: center;
+  margin-top: 10%;
+  background-color: #e3ecf1;
+  height: 30%;
+`;
+
+const DetailView = ({ location: { state } }) => {
+  const item = state.item;
+  console.log(item.title);
+  return (
+    <>
+      <Header></Header>
+      <DetailContainer>
+        <DetailItem>
+          <div>{`${item.title}`}</div>
+        </DetailItem>
+      </DetailContainer>
+      <Footer></Footer>
+    </>
+  );
+};
+
+export default DetailView;

--- a/front/black-gomushin/src/pages/DetailView.jsx
+++ b/front/black-gomushin/src/pages/DetailView.jsx
@@ -4,6 +4,7 @@ import Header from '../components/common/header';
 import Footer from '../components/common/footer';
 import MessageIcon from '@material-ui/icons/Message';
 import { useHistory } from 'react-router-dom';
+import refresh from '../utils/refresh';
 
 const DetailContainer = styled.div`
   display: flex;
@@ -39,27 +40,30 @@ const MessageIconBox = styled(MessageIcon)`
 
 const DetailView = ({ location: { state } }) => {
   const history = useHistory();
-  const item = state.item;
-  return (
-    <>
-      <Header></Header>
-      <DetailContainer>
-        <ItemImg src={item.imageurl}></ItemImg>
-        <DetailItem>
-          <div>{`${item.title}`}</div>
-          <div>{`${item.state}`}</div>
-          <div>{`${item.price}원`}</div>
-          <div>{`${item.content}`}</div>
-          <div>{`판매자${item.sell_username}`}</div>
-          <div>{`조회수 ${item.view}`}</div>
-          <div>{`사이즈 ${item.size}`}</div>
-          <div>{`${item.publish_date}`}</div>
-          <MessageIconBox onClick={() => history.push('/')}></MessageIconBox>
-        </DetailItem>
-      </DetailContainer>
-      <Footer></Footer>
-    </>
-  );
+  if (state) {
+    const item = state.item;
+    return (
+      <>
+        <Header></Header>
+        <DetailContainer>
+          <ItemImg src={item.imageurl}></ItemImg>
+          <DetailItem>
+            <div>{`${item.title}`}</div>
+            <div>{`${item.state}`}</div>
+            <div>{`${item.price}원`}</div>
+            <div>{`${item.content}`}</div>
+            <div>{`판매자${item.sell_username}`}</div>
+            <div>{`조회수 ${item.view}`}</div>
+            <div>{`사이즈 ${item.size}`}</div>
+            <div>{`${item.publish_date}`}</div>
+            <MessageIconBox onClick={() => history.push('/')}></MessageIconBox>
+          </DetailItem>
+        </DetailContainer>
+        <Footer></Footer>
+      </>
+    );
+  }
+  return refresh();
 };
 
 export default DetailView;

--- a/front/black-gomushin/src/pages/DetailView.jsx
+++ b/front/black-gomushin/src/pages/DetailView.jsx
@@ -2,6 +2,8 @@ import React from 'react';
 import styled from 'styled-components';
 import Header from '../components/common/header';
 import Footer from '../components/common/footer';
+import MessageIcon from '@material-ui/icons/Message';
+import { useHistory } from 'react-router-dom';
 
 const DetailContainer = styled.div`
   display: flex;
@@ -27,7 +29,16 @@ const DetailItem = styled.div`
   height: 40vh;
 `;
 
+const MessageIconBox = styled(MessageIcon)`
+  color: red;
+  &:hover {
+    cursor: pointer;
+    transform: scale(3);
+  }
+`;
+
 const DetailView = ({ location: { state } }) => {
+  const history = useHistory();
   const item = state.item;
   return (
     <>
@@ -43,6 +54,7 @@ const DetailView = ({ location: { state } }) => {
           <div>{`조회수 ${item.view}`}</div>
           <div>{`사이즈 ${item.size}`}</div>
           <div>{`${item.publish_date}`}</div>
+          <MessageIconBox onClick={() => history.push('/')}></MessageIconBox>
         </DetailItem>
       </DetailContainer>
       <Footer></Footer>

--- a/front/black-gomushin/src/pages/DetailView.jsx
+++ b/front/black-gomushin/src/pages/DetailView.jsx
@@ -6,28 +6,43 @@ import Footer from '../components/common/footer';
 const DetailContainer = styled.div`
   display: flex;
   width: 100%;
-  height: 100%;
+  height: 60%;
   flex-direction: column;
   justify-content: center;
+  align-items: center;
+`;
+
+const ItemImg = styled.img`
+  display: flex;
+  max-height: 40vh;
+  max-width: 40vh;
+  padding-top: 5%;
 `;
 
 const DetailItem = styled.div`
   display: flex;
-  justify-content: center;
-  margin-top: 10%;
+  flex-direction: column;
+  align-items: center;
   background-color: #e3ecf1;
-  height: 30%;
+  height: 40vh;
 `;
 
 const DetailView = ({ location: { state } }) => {
   const item = state.item;
-  console.log(item.title);
   return (
     <>
       <Header></Header>
       <DetailContainer>
+        <ItemImg src={item.imageurl}></ItemImg>
         <DetailItem>
           <div>{`${item.title}`}</div>
+          <div>{`${item.state}`}</div>
+          <div>{`${item.price}원`}</div>
+          <div>{`${item.content}`}</div>
+          <div>{`판매자${item.sell_username}`}</div>
+          <div>{`조회수 ${item.view}`}</div>
+          <div>{`사이즈 ${item.size}`}</div>
+          <div>{`${item.publish_date}`}</div>
         </DetailItem>
       </DetailContainer>
       <Footer></Footer>


### PR DESCRIPTION
### 📕 Issue Number

Close #21 #53 


<br/>

### 📗 작업 내역

> 구현 내용 및 작업 했던 내역

### Detail View 구현
- ![](https://i.imgur.com/har5Fo3.png)
- Header Component, Footer Component 재활용
- UI 레이아웃 구축
- 판매자와 채팅앱 연결을 위한 icon 버튼 구축 (현재 링크는 메인으로)

#### 페이지 이동 props 
- history 객체의 location.state 활용
```jsx
onClick={() => history.push('/detail', { item })}
```
- history.push 사용시 인자로 state 를 넘길 수 있다.
```jsx
const DetailView = ({ location: { state } }) => {
  const history = useHistory();
  if (state) {
    const item = state.item;
    return (<Component>...</Component>)
  return refresh();
```
- location.state 를 구조분해 할당을 받아 state.item 으로 push 로 보낸 state의 item 을 해당 컴포넌트에서 사용할 수 있다.
- state 가 없이 detail 페이지로 진입한 경우 main 으로 refresh 하여 잘못된 접근을 막는다.


<br/>

### 📘 작업 유형

- 신규 기능 추가

<br/>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 채팅 페이지 이동은 추후 구현
- 디자인 추후 구현

<br/><br/>
